### PR TITLE
EOBS-2068 Automate page visibility

### DIFF
--- a/liveobs_ui/page_object_models/common/background_setup.py
+++ b/liveobs_ui/page_object_models/common/background_setup.py
@@ -101,7 +101,7 @@ def assign_user_roles(client, name, role):
     group_model = client.model('res.groups')
     category_model = client.model('res.partner.category')
     #
-    # TODO EOBS-2335
+    # Refactor: EOBS-2335
     #
     if role == 'System Administrator':
         user_role = get_role_id_for_group(

--- a/liveobs_ui/page_object_models/common/background_setup.py
+++ b/liveobs_ui/page_object_models/common/background_setup.py
@@ -100,10 +100,19 @@ def assign_user_roles(client, name, role):
     """
     group_model = client.model('res.groups')
     category_model = client.model('res.partner.category')
-    user_role = get_role_id_for_group(
-        group_model,
-        'NH Clinical {} Group'.format(role)
-    )
+    #
+    # TODO EOBS-2335
+    #
+    if role == 'System Administrator':
+        user_role = get_role_id_for_group(
+            group_model,
+            'NH Clinical {} Group'.format('Admin')
+        )
+    else:
+        user_role = get_role_id_for_group(
+            group_model,
+            'NH Clinical {} Group'.format(role)
+        )
     role_category = get_role_id_for_category(category_model, role)
     user = get_user_record(client, name)
     if user:

--- a/liveobs_ui/page_object_models/common/base_liveobs_page.py
+++ b/liveobs_ui/page_object_models/common/base_liveobs_page.py
@@ -9,6 +9,9 @@ from selenium.webdriver.support.select import Select
 from selenium.common.exceptions import ElementNotVisibleException
 from liveobs_ui.selectors.desktop.form_selectors import \
     FORM_VIEW_AUTOCOMPLETE_CONTAINER
+from liveobs_ui.selectors.desktop.navigation_selectors import \
+    LEFT_NAVIGATION_ITEMS
+from liveobs_ui.selectors.mobile.header import HEADER_CONTAINER
 from liveobs_ui.selectors.mobile.get_selector_by_lookup \
     import get_element_selector
 
@@ -142,7 +145,6 @@ class BaseLiveObsPage(object):
 
     def enter_many2one_tag_value(self, element, value):
         """
-
         Add value to many2one tag input then verify that the tag has been added
 
         :param element: many2one tag input element
@@ -192,3 +194,15 @@ class BaseLiveObsPage(object):
         :return: webelement
         """
         return self.driver.find_element(*get_element_selector(element_name))
+
+    def verify_page_loaded(self, app_view):
+        """
+        Waits for a specific element to be visible on the screen the 'desktop'
+        or 'mobile' app to ensure the page has loaded before progressing
+
+        :param app_view: Either 'mobile' or 'desktop'
+        """
+        if app_view == 'desktop':
+            self.wait_for_element(LEFT_NAVIGATION_ITEMS)
+        else:
+            self.wait_for_element(HEADER_CONTAINER)

--- a/liveobs_ui/page_object_models/desktop/desktop_common.py
+++ b/liveobs_ui/page_object_models/desktop/desktop_common.py
@@ -2,7 +2,7 @@
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
 from liveobs_ui.selectors.desktop.navigation_selectors import \
-    LEFT_NAVIGATION_ITEMS
+    LEFT_NAVIGATION_ITEMS, LEFT_NAVIGATION_ITEMS_NAME
 from liveobs_ui.selectors.desktop.search_selectors import \
     SEARCH_OPTIONS_DRAW_BUTTON, SEARCH_DRAWER, SEARCH_DRAWER_FILTER_ITEMS, \
     SEARCH_DRAWER_GROUP_BY_ITEMS, SEARCH_INPUT, SEARCH_AUTOCOMPLETE, \
@@ -200,3 +200,27 @@ class BaseDesktopPage(BaseLiveObsPage):
         if breadcrumbs:
             breadcrumb = breadcrumbs[-1]
             self.click_breadcrumb(breadcrumb)
+
+    def get_menu_items_list(self):
+        """
+        Returns a list of all the items in the left menu section on the
+        desktop app
+
+        :return: A list of all the WebElement items
+        :rtype: List of WebElements
+        """
+        return self.driver.find_elements(*LEFT_NAVIGATION_ITEMS)
+
+    @staticmethod
+    def get_menu_item_text(menu_item):
+        """
+        Returns the text attribute of an element on an item
+        in the left menu section on the desktop app
+
+        :param menu_item: WebElement from where to get the text element
+        :return: The text within the WebElement
+        :rtype: unicode
+        """
+
+        menu_info = menu_item.find_element(*LEFT_NAVIGATION_ITEMS_NAME)
+        return menu_info.text

--- a/liveobs_ui/page_object_models/desktop/desktop_common.py
+++ b/liveobs_ui/page_object_models/desktop/desktop_common.py
@@ -221,6 +221,5 @@ class BaseDesktopPage(BaseLiveObsPage):
         :return: The text within the WebElement
         :rtype: unicode
         """
-
         menu_info = menu_item.find_element(*LEFT_NAVIGATION_ITEMS_NAME)
         return menu_info.text

--- a/liveobs_ui/selectors/desktop/navigation_selectors.py
+++ b/liveobs_ui/selectors/desktop/navigation_selectors.py
@@ -18,3 +18,6 @@ LEFT_NAVIGATION_ITEMS = (
     'td.oe_leftbar .oe_secondary_menus_container '
     '.oe_secondary_menu .oe_secondary_submenu li a'
 )
+
+LEFT_NAVIGATION_ITEMS_NAME = (
+    By.CSS_SELECTOR, '.oe_secondary_submenu li a .oe_menu_text')

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ flake8==3.3.0
 pylint==1.7.5
 selenium==3.4.2
 sphinx==1.6.1
+astroid==1.5.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 flake8==3.3.0
+ # Updated pylint version and added astroid dependency to fix Travis
+ # failure on Python3 run https://github.com/PyCQA/pylint/issues/1784
 pylint==1.7.5
+astroid==1.5.3
 selenium==3.4.2
 sphinx==1.6.1
-astroid==1.5.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 flake8==3.3.0
-pylint==1.7.1
+pylint==1.7.5
 selenium==3.4.2
 sphinx==1.6.1


### PR DESCRIPTION
# Functionality Added
- background_setup: added (TODO) condition to assign to System Admin group
- base_liveobs_page: added verify_page_loaded method
- desktop_common: added methods get_menu_items_list and get_menu_item_text
- navigation_selectors: added LEFT_NAVIGATION_ITEMS_NAME selector
# Functionality Removed
N/A
# Possible Side Effects of Changes
Added a TODO as part of a quick refactor of the assign_user_roles method, which brought down the pylint score to 9.99. Tech debt EOBS-2335 raised to fix this.
# Checks
- [ ] Linting passing
- [ ] Documentation up to date
- [ ] Timings on expected conditions reviewed
- [ ] Deprecated selectors reviewed
- [ ] Code re-usability reviewed